### PR TITLE
Arm m1 support

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -21,9 +21,9 @@
 
 {port_specs, [{"priv/emcl_nif.so", ["c_src/*.c"]}]}.
 
-{port_env, [ {"darwin", "CFLAGS", "$CFLAGS -fPIC -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes -I c_src/mcl/include"}
-           , {"darwin", "CXXFLAGS", "$CXXFLAGS -fPIC -O3 -arch x86_64 -finline-functions -Wall"}
-           , {"darwin", "LDFLAGS", "$LDFLAGS -arch x86_64 c_src/mcl/lib/libmclbn384_256.a c_src/mcl/lib/libmcl.a -lgmp"}
+{port_env, [ {"darwin", "CFLAGS", "$CFLAGS -fPIC -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes -I c_src/mcl/include"}
+           , {"darwin", "CXXFLAGS", "$CXXFLAGS -fPIC -O3 -finline-functions -Wall"}
+           , {"darwin", "LDFLAGS", "$LDFLAGS c_src/mcl/lib/libmclbn384_256.a c_src/mcl/lib/libmcl.a -lgmp"}
 
            , {"linux", "CFLAGS", "$CFLAGS -fPIC -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes -I c_src/mcl/include"}
            , {"linux", "CXXFLAGS", "$CXXFLAGS -fPIC -O3 -finline-functions -Wall"}


### PR DESCRIPTION
Update the submodule pointer to a recent mcl and allow builds of non x86_64.

This PR is sponsored by the ACF